### PR TITLE
Fix. Remove unused hot reload module

### DIFF
--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -6,7 +6,6 @@ const webpackCommonConfig = require("./webpack.config.common");
 module.exports = merge(webpackCommonConfig, {
 	mode: "development",
   plugins: [
-    new webpack.HotModuleReplacementPlugin(),
     new webpack.EnvironmentPlugin({ NODE_ENV: "development" }),
   ],
   performance: {


### PR DESCRIPTION
Since webpack option "hot: true" applies HMR plugin, it can be deleted from webpack config